### PR TITLE
Add GUI setup and Typer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# SNS Dashboard
+
+This project provides a simple GUI setup tool for storing API credentials for Google, Instagram, TikTok and a spreadsheet. The credentials are saved in `config.json` and can be used by other parts of the application.
+
+## Usage
+
+Install dependencies first:
+
+```bash
+pip install typer tkinter
+```
+
+To launch the GUI, run:
+
+```bash
+python -m sns_dashboard.main setup
+```
+
+If packaged as an executable, you can invoke the setup with:
+
+```bash
+sns-dashboard.exe setup
+```
+
+Fill out each field in the window and press **Save**. The configuration will be written to `config.json` and an initial authentication step will run.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "google_client_id": "",
+  "google_client_secret": "",
+  "instagram_client_id": "",
+  "instagram_client_secret": "",
+  "tiktok_client_key": "",
+  "tiktok_client_secret": "",
+  "spreadsheet_id": ""
+}

--- a/sns_dashboard/auth.py
+++ b/sns_dashboard/auth.py
@@ -1,0 +1,16 @@
+import json
+import os
+
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config.json')
+
+
+def get_token():
+    """Simulate initial authentication using stored credentials."""
+    if not os.path.exists(CONFIG_FILE):
+        print('No configuration found.')
+        return None
+    with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+    print('Performing initial authentication...')
+    # Placeholder for real authentication logic
+    return config

--- a/sns_dashboard/gui.py
+++ b/sns_dashboard/gui.py
@@ -1,0 +1,61 @@
+import json
+import os
+import tkinter as tk
+from tkinter import messagebox
+
+from .auth import get_token
+
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config.json')
+
+
+class SetupGUI:
+    def __init__(self, master: tk.Tk):
+        self.master = master
+        master.title('SNS Dashboard Setup')
+
+        self.entries = {}
+        fields = [
+            ('Google Client ID', 'google_client_id'),
+            ('Google Client Secret', 'google_client_secret'),
+            ('Instagram Client ID', 'instagram_client_id'),
+            ('Instagram Client Secret', 'instagram_client_secret'),
+            ('TikTok Client Key', 'tiktok_client_key'),
+            ('TikTok Client Secret', 'tiktok_client_secret'),
+            ('Spreadsheet ID', 'spreadsheet_id'),
+        ]
+
+        for i, (label_text, key) in enumerate(fields):
+            tk.Label(master, text=label_text).grid(row=i, column=0, sticky='e', pady=2, padx=2)
+            entry = tk.Entry(master, width=40)
+            entry.grid(row=i, column=1, pady=2, padx=2)
+            self.entries[key] = entry
+
+        tk.Button(master, text='Save', command=self.save).grid(row=len(fields), column=0, columnspan=2, pady=10)
+
+        self.load_existing()
+
+    def load_existing(self):
+        if not os.path.exists(CONFIG_FILE):
+            return
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        for key, entry in self.entries.items():
+            if key in data:
+                entry.delete(0, tk.END)
+                entry.insert(0, data[key])
+
+    def save(self):
+        data = {key: entry.get().strip() for key, entry in self.entries.items()}
+        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+        messagebox.showinfo('Saved', 'Configuration saved.')
+        get_token()
+
+def run():
+    root = tk.Tk()
+    SetupGUI(root)
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    run()

--- a/sns_dashboard/main.py
+++ b/sns_dashboard/main.py
@@ -1,0 +1,21 @@
+import typer
+
+from .gui import run as run_gui
+
+app = typer.Typer(help='SNS Dashboard Command Line Interface')
+
+
+@app.callback()
+def main() -> None:
+    """SNS Dashboard CLI."""
+    pass
+
+
+@app.command()
+def setup() -> None:
+    """Launch GUI setup window."""
+    run_gui()
+
+
+if __name__ == '__main__':
+    app()


### PR DESCRIPTION
## Summary
- create `sns_dashboard` package
- add Tkinter GUI for credential entry with save to `config.json`
- implement basic `auth.get_token` simulation
- add CLI entrypoint with Typer and `setup` command
- document usage in `README`

## Testing
- `python -m sns_dashboard.main --help`
- `python -m sns_dashboard.main setup` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_686e6e92073483298dd1a233bcc3f75e