### PR TITLE
Add daily scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+data.db

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SNS Dashboard
 
-This project provides a simple GUI setup tool for storing API credentials for Google, Instagram, TikTok and a spreadsheet. The credentials are saved in `config.json` and can be used by other parts of the application.
+This project collects daily view counts from YouTube, TikTok and Instagram channels and computes estimated revenue. Credentials and channel information are stored in `config.json` through a small Tkinter GUI.
 
 ## Usage
 
 Install dependencies first:
 
 ```bash
-pip install typer tkinter
+pip install typer apscheduler matplotlib tkinter
 ```
 
 To launch the GUI, run one of:
@@ -39,6 +39,8 @@ sns-dashboard.exe setup
 
 Fill out each field in the window and press **Save**. The configuration will be written to `config.json` and an initial authentication step will run.
 
+Fields include API credentials, channel URLs and CPM rates for each platform.
+
 ## Scheduled Data Collection
 
 After completing the setup you can start a background process that collects
@@ -48,5 +50,10 @@ data each day at midnight:
 python -m sns_dashboard run
 ```
 
-This command runs indefinitely, waking up at 00:00 every day to execute the
-data collection routine.
+This command initializes the SQLite database and schedules a fetch job every day at 00:00.
+
+Collected data can be visualized with:
+
+```bash
+python -m sns_dashboard plot
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project collects daily view counts from YouTube, TikTok and Instagram chann
 Install dependencies first:
 
 ```bash
-pip install typer apscheduler matplotlib tkinter
+pip install -r requirements.txt
 ```
 
 To launch the GUI, run one of:
@@ -28,7 +28,7 @@ You can also execute the script directly:
 python sns_dashboard/main.py setup
 ```
 
-Running `python sns_dashboard/main.py` without any arguments will launch the setup window on first run. If `config.json` already exists and is filled out, the scheduler starts automatically instead.
+Running `python sns_dashboard/main.py` without any arguments will launch the setup window on first run. If `config.json` already exists and is filled out, the scheduler starts automatically instead. You can also run `python -m sns_dashboard` for the same behavior.
 
 If packaged as an executable, you can invoke the setup with:
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ You can also execute the script directly:
 python sns_dashboard/main.py setup
 ```
 
-Running `python sns_dashboard/main.py` without any arguments will launch the
-setup window on first run. If `config.json` already exists and is filled out,
-the scheduler starts automatically instead.
+Running `python sns_dashboard/main.py` without any arguments will launch the setup window on first run. If `config.json` already exists and is filled out, the scheduler starts automatically instead.
 
 If packaged as an executable, you can invoke the setup with:
 
@@ -38,14 +36,11 @@ If packaged as an executable, you can invoke the setup with:
 sns-dashboard.exe setup
 ```
 
-Fill out each field in the window and press **Save**. The configuration will be written to `config.json` and an initial authentication step will run.
-
-Fields include API credentials, channel URLs and CPM rates for each platform.
+Fill out each field in the window and press **Save**. The configuration will be written to `config.json` and an initial authentication step will run. Fields include API credentials, channel URLs and CPM rates for each platform.
 
 ## Scheduled Data Collection
 
-After completing the setup you can start a background process that collects
-data each day at midnight:
+After completing the setup you can start a background process that collects data each day at midnight:
 
 ```bash
 python -m sns_dashboard run

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ You can also execute the script directly:
 python sns_dashboard/main.py setup
 ```
 
-Running `python sns_dashboard/main.py` without any arguments will default to
-launching the setup window as well.
+Running `python sns_dashboard/main.py` without any arguments will launch the
+setup window on first run. If `config.json` already exists and is filled out,
+the scheduler starts automatically instead.
 
 If packaged as an executable, you can invoke the setup with:
 
@@ -51,6 +52,14 @@ python -m sns_dashboard run
 ```
 
 This command initializes the SQLite database and schedules a fetch job every day at 00:00.
+
+If the configuration file already exists, you can simply run:
+
+```bash
+python -m sns_dashboard
+```
+
+or run the packaged executable to start the scheduler immediately.
 
 Collected data can be visualized with:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# SNS Dashboard
+
+This project provides a simple GUI setup tool for storing API credentials for Google, Instagram, TikTok and a spreadsheet. The credentials are saved in `config.json` and can be used by other parts of the application.
+
+## Usage
+
+Install dependencies first:
+
+```bash
+pip install typer tkinter
+```
+
+To launch the GUI, run one of:
+
+```bash
+python -m sns_dashboard setup
+```
+
+or
+
+```bash
+python -m sns_dashboard.main setup
+```
+
+You can also execute the script directly:
+
+```bash
+python sns_dashboard/main.py setup
+```
+
+Running `python sns_dashboard/main.py` without any arguments will default to
+launching the setup window as well.
+
+If packaged as an executable, you can invoke the setup with:
+
+```bash
+sns-dashboard.exe setup
+```
+
+Fill out each field in the window and press **Save**. The configuration will be written to `config.json` and an initial authentication step will run.
+
+## Scheduled Data Collection
+
+After completing the setup you can start a background process that collects
+data each day at midnight:
+
+```bash
+python -m sns_dashboard run
+```
+
+This command runs indefinitely, waking up at 00:00 every day to execute the
+data collection routine.

--- a/config.json
+++ b/config.json
@@ -5,5 +5,13 @@
   "instagram_client_secret": "",
   "tiktok_client_key": "",
   "tiktok_client_secret": "",
-  "spreadsheet_id": ""
+  "spreadsheet_id": "",
+  "youtube_url": "",
+  "tiktok_url": "",
+  "instagram_url": "",
+  "rates": {
+    "youtube": 0,
+    "tiktok": 0,
+    "instagram": 0
+  }
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "google_client_id": "",
+  "google_client_secret": "",
+  "instagram_client_id": "",
+  "instagram_client_secret": "",
+  "tiktok_client_key": "",
+  "tiktok_client_secret": "",
+  "spreadsheet_id": ""
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+typer
+apscheduler
+matplotlib

--- a/sns_dashboard/__main__.py
+++ b/sns_dashboard/__main__.py
@@ -1,0 +1,4 @@
+from .main import app
+
+if __name__ == "__main__":
+    app()

--- a/sns_dashboard/auth.py
+++ b/sns_dashboard/auth.py
@@ -1,0 +1,16 @@
+import json
+import os
+
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config.json')
+
+
+def get_token():
+    """Simulate initial authentication using stored credentials."""
+    if not os.path.exists(CONFIG_FILE):
+        print('No configuration found.')
+        return None
+    with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+    print('Performing initial authentication...')
+    # Placeholder for real authentication logic
+    return config

--- a/sns_dashboard/config.py
+++ b/sns_dashboard/config.py
@@ -1,0 +1,35 @@
+import json
+import os
+from typing import Any, Dict
+
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.json")
+
+DEFAULT_CONFIG = {
+    "google_client_id": "",
+    "google_client_secret": "",
+    "instagram_client_id": "",
+    "instagram_client_secret": "",
+    "tiktok_client_key": "",
+    "tiktok_client_secret": "",
+    "spreadsheet_id": "",
+    "youtube_url": "",
+    "tiktok_url": "",
+    "instagram_url": "",
+    "rates": {
+        "youtube": 0.0,
+        "tiktok": 0.0,
+        "instagram": 0.0,
+    },
+}
+
+
+def load_config() -> Dict[str, Any]:
+    if not os.path.exists(CONFIG_PATH):
+        return DEFAULT_CONFIG.copy()
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)

--- a/sns_dashboard/config.py
+++ b/sns_dashboard/config.py
@@ -23,6 +23,27 @@ DEFAULT_CONFIG = {
 }
 
 
+def config_exists() -> bool:
+    """Return True if the configuration file exists."""
+    return os.path.exists(CONFIG_PATH)
+
+
+def is_config_complete(cfg: Dict[str, Any]) -> bool:
+    required = [
+        "google_client_id",
+        "google_client_secret",
+        "instagram_client_id",
+        "instagram_client_secret",
+        "tiktok_client_key",
+        "tiktok_client_secret",
+        "spreadsheet_id",
+        "youtube_url",
+        "tiktok_url",
+        "instagram_url",
+    ]
+    return all(cfg.get(k) for k in required)
+
+
 def load_config() -> Dict[str, Any]:
     if not os.path.exists(CONFIG_PATH):
         return DEFAULT_CONFIG.copy()

--- a/sns_dashboard/db.py
+++ b/sns_dashboard/db.py
@@ -1,0 +1,73 @@
+import os
+import sqlite3
+from typing import Iterable, Tuple
+
+DB_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data.db")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS channels (
+    platform TEXT PRIMARY KEY,
+    url TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rates (
+    platform TEXT PRIMARY KEY,
+    cpm REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS views (
+    platform TEXT,
+    date DATE,
+    views INTEGER,
+    PRIMARY KEY(platform, date)
+);
+
+CREATE VIEW IF NOT EXISTS earnings AS
+SELECT v.platform,
+       v.date,
+       v.views,
+       ROUND(v.views / 1000.0 * r.cpm, 2) AS revenue
+FROM   views v
+JOIN   rates r USING(platform);
+
+CREATE VIEW IF NOT EXISTS views_monthly AS
+SELECT platform,
+       substr(date, 1, 7) AS yyyymm,
+       SUM(views) AS views_month
+FROM views
+GROUP BY platform, yyyymm;
+
+CREATE VIEW IF NOT EXISTS earnings_monthly AS
+SELECT v.platform,
+       v.yyyymm,
+       v.views_month,
+       ROUND(v.views_month / 1000.0 * r.cpm, 2) AS revenue_month
+FROM views_monthly v
+JOIN rates r USING(platform);
+"""
+
+
+def get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    conn = get_conn()
+    conn.executescript(SCHEMA)
+    conn.commit()
+
+
+def insert_views(platform: str, date: str, views: int) -> None:
+    conn = get_conn()
+    conn.execute(
+        "INSERT OR REPLACE INTO views(platform, date, views) VALUES (?, ?, ?)",
+        (platform, date, views),
+    )
+    conn.commit()
+
+
+def get_daily_views() -> Iterable[Tuple[str, str, int]]:
+    conn = get_conn()
+    return conn.execute("SELECT platform, date, views FROM views ORDER BY date").fetchall()

--- a/sns_dashboard/earnings.py
+++ b/sns_dashboard/earnings.py
@@ -1,0 +1,10 @@
+from .db import get_conn
+
+
+def update_today() -> None:
+    # Simple calculation using views and rates tables
+    conn = get_conn()
+    conn.execute(
+        "INSERT OR REPLACE INTO earnings SELECT v.platform, v.date, v.views, ROUND(v.views / 1000.0 * r.cpm, 2) FROM views v JOIN rates r USING(platform)"
+    )
+    conn.commit()

--- a/sns_dashboard/fetchers/instagram.py
+++ b/sns_dashboard/fetchers/instagram.py
@@ -1,0 +1,4 @@
+def get_channel_views() -> int:
+    """Return total lifetime views for the given Instagram account."""
+    print("Fetching Instagram views (stub)")
+    return 0

--- a/sns_dashboard/fetchers/tiktok.py
+++ b/sns_dashboard/fetchers/tiktok.py
@@ -1,0 +1,4 @@
+def get_channel_views() -> int:
+    """Return total lifetime views for the given TikTok channel."""
+    print("Fetching TikTok views (stub)")
+    return 0

--- a/sns_dashboard/fetchers/youtube.py
+++ b/sns_dashboard/fetchers/youtube.py
@@ -1,0 +1,5 @@
+def get_channel_views() -> int:
+    """Return total lifetime views for the given YouTube channel."""
+    # TODO: implement actual API call
+    print("Fetching YouTube views (stub)")
+    return 0

--- a/sns_dashboard/gui.py
+++ b/sns_dashboard/gui.py
@@ -55,15 +55,15 @@ class SetupGUI:
             if key.startswith('rate_'):
                 continue
             data[key] = entry.get().strip()
-        # rates nested structure
-        rates = data.get("rates", {})
-        rates["youtube"] = float(self.entries["rate_youtube"].get() or 0)
-        rates["tiktok"] = float(self.entries["rate_tiktok"].get() or 0)
-        rates["instagram"] = float(self.entries["rate_instagram"].get() or 0)
-        data["rates"] = rates
+        rates = data.get('rates', {})
+        rates['youtube'] = float(self.entries['rate_youtube'].get() or 0)
+        rates['tiktok'] = float(self.entries['rate_tiktok'].get() or 0)
+        rates['instagram'] = float(self.entries['rate_instagram'].get() or 0)
+        data['rates'] = rates
         save_config(data)
         messagebox.showinfo('Saved', 'Configuration saved.')
         get_token()
+
 
 def run():
     root = tk.Tk()

--- a/sns_dashboard/gui.py
+++ b/sns_dashboard/gui.py
@@ -1,0 +1,61 @@
+import json
+import os
+import tkinter as tk
+from tkinter import messagebox
+
+from .auth import get_token
+
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config.json')
+
+
+class SetupGUI:
+    def __init__(self, master: tk.Tk):
+        self.master = master
+        master.title('SNS Dashboard Setup')
+
+        self.entries = {}
+        fields = [
+            ('Google Client ID', 'google_client_id'),
+            ('Google Client Secret', 'google_client_secret'),
+            ('Instagram Client ID', 'instagram_client_id'),
+            ('Instagram Client Secret', 'instagram_client_secret'),
+            ('TikTok Client Key', 'tiktok_client_key'),
+            ('TikTok Client Secret', 'tiktok_client_secret'),
+            ('Spreadsheet ID', 'spreadsheet_id'),
+        ]
+
+        for i, (label_text, key) in enumerate(fields):
+            tk.Label(master, text=label_text).grid(row=i, column=0, sticky='e', pady=2, padx=2)
+            entry = tk.Entry(master, width=40)
+            entry.grid(row=i, column=1, pady=2, padx=2)
+            self.entries[key] = entry
+
+        tk.Button(master, text='Save', command=self.save).grid(row=len(fields), column=0, columnspan=2, pady=10)
+
+        self.load_existing()
+
+    def load_existing(self):
+        if not os.path.exists(CONFIG_FILE):
+            return
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        for key, entry in self.entries.items():
+            if key in data:
+                entry.delete(0, tk.END)
+                entry.insert(0, data[key])
+
+    def save(self):
+        data = {key: entry.get().strip() for key, entry in self.entries.items()}
+        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+        messagebox.showinfo('Saved', 'Configuration saved.')
+        get_token()
+
+def run():
+    root = tk.Tk()
+    SetupGUI(root)
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    run()

--- a/sns_dashboard/main.py
+++ b/sns_dashboard/main.py
@@ -10,6 +10,7 @@ from sns_dashboard.gui import run as run_gui
 from sns_dashboard.scheduler import start as start_scheduler
 from sns_dashboard.viz import plot_views
 from sns_dashboard.db import init_db
+from sns_dashboard.config import load_config, config_exists, is_config_complete
 
 app = typer.Typer(help='SNS Dashboard Command Line Interface')
 
@@ -46,7 +47,11 @@ def plot() -> None:
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
-        # Allow running `python sns_dashboard/main.py` directly
-        # by defaulting to the setup command when no arguments are given.
-        sys.argv.append('setup')
+        cfg = load_config() if config_exists() else None
+        if cfg is None or not is_config_complete(cfg):
+            # First run or incomplete config -> launch setup GUI
+            sys.argv.append('setup')
+        else:
+            # Auto-start scheduler when configuration is present
+            sys.argv.append('run')
     app()

--- a/sns_dashboard/main.py
+++ b/sns_dashboard/main.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import typer
+
+if __package__ is None or __package__ == "":
+    # Adjust path so absolute imports work when running directly
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from sns_dashboard.gui import run as run_gui
+from sns_dashboard.tasks import fetch_data
+import time
+from datetime import datetime, timedelta
+
+app = typer.Typer(help='SNS Dashboard Command Line Interface')
+
+
+@app.callback()
+def main() -> None:
+    """SNS Dashboard CLI."""
+    pass
+
+
+@app.command()
+def setup() -> None:
+    """Launch GUI setup window."""
+    run_gui()
+
+
+@app.command()
+def run() -> None:
+    """Fetch data every day at midnight."""
+    while True:
+        now = datetime.now()
+        next_midnight = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        time.sleep((next_midnight - now).total_seconds())
+        fetch_data()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        # Allow running `python sns_dashboard/main.py` directly
+        # by defaulting to the setup command when no arguments are given.
+        sys.argv.append('setup')
+    app()

--- a/sns_dashboard/main.py
+++ b/sns_dashboard/main.py
@@ -49,9 +49,7 @@ if __name__ == '__main__':
     if len(sys.argv) == 1:
         cfg = load_config() if config_exists() else None
         if cfg is None or not is_config_complete(cfg):
-            # First run or incomplete config -> launch setup GUI
             sys.argv.append('setup')
         else:
-            # Auto-start scheduler when configuration is present
             sys.argv.append('run')
     app()

--- a/sns_dashboard/main.py
+++ b/sns_dashboard/main.py
@@ -1,15 +1,15 @@
 import os
 import sys
+import time
 import typer
 
 if __package__ is None or __package__ == "":
-    # Adjust path so absolute imports work when running directly
     sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from sns_dashboard.gui import run as run_gui
-from sns_dashboard.tasks import fetch_data
-import time
-from datetime import datetime, timedelta
+from sns_dashboard.scheduler import start as start_scheduler
+from sns_dashboard.viz import plot_views
+from sns_dashboard.db import init_db
 
 app = typer.Typer(help='SNS Dashboard Command Line Interface')
 
@@ -28,12 +28,20 @@ def setup() -> None:
 
 @app.command()
 def run() -> None:
-    """Fetch data every day at midnight."""
-    while True:
-        now = datetime.now()
-        next_midnight = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
-        time.sleep((next_midnight - now).total_seconds())
-        fetch_data()
+    """Start scheduler for daily data fetch."""
+    init_db()
+    start_scheduler()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+@app.command()
+def plot() -> None:
+    """Display a simple plot of collected views."""
+    plot_views()
 
 
 if __name__ == '__main__':

--- a/sns_dashboard/scheduler.py
+++ b/sns_dashboard/scheduler.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from .fetchers.youtube import get_channel_views as youtube_views
+from .fetchers.tiktok import get_channel_views as tiktok_views
+from .fetchers.instagram import get_channel_views as instagram_views
+from .db import insert_views
+
+scheduler = BackgroundScheduler(timezone="Asia/Seoul")
+
+
+def job_fetch_views() -> None:
+    today = datetime.now().date().isoformat()
+    insert_views("youtube", today, youtube_views())
+    insert_views("tiktok", today, tiktok_views())
+    insert_views("instagram", today, instagram_views())
+
+
+def start() -> None:
+    if not scheduler.get_job("daily_fetch"):
+        scheduler.add_job(job_fetch_views, "cron", hour=0, id="daily_fetch")
+    scheduler.start()
+    job_fetch_views()

--- a/sns_dashboard/scheduler.py
+++ b/sns_dashboard/scheduler.py
@@ -11,6 +11,7 @@ scheduler = BackgroundScheduler(timezone="Asia/Seoul")
 
 def job_fetch_views() -> None:
     today = datetime.now().date().isoformat()
+    print(f"Fetching views for {today}")
     insert_views("youtube", today, youtube_views())
     insert_views("tiktok", today, tiktok_views())
     insert_views("instagram", today, instagram_views())
@@ -20,4 +21,5 @@ def start() -> None:
     if not scheduler.get_job("daily_fetch"):
         scheduler.add_job(job_fetch_views, "cron", hour=0, id="daily_fetch")
     scheduler.start()
+    print("Scheduler started. Running initial fetch...")
     job_fetch_views()

--- a/sns_dashboard/tasks.py
+++ b/sns_dashboard/tasks.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 
 from .scheduler import job_fetch_views
+from .db import init_db
 
 
 def fetch_data() -> None:
     """Run a single data fetch immediately."""
     print(f"Manual fetch at {datetime.now().isoformat()}")
+    init_db()
     job_fetch_views()
 

--- a/sns_dashboard/tasks.py
+++ b/sns_dashboard/tasks.py
@@ -1,8 +1,10 @@
-import datetime
+from datetime import datetime
+
+from .scheduler import job_fetch_views
 
 
 def fetch_data() -> None:
-    """Placeholder for daily data collection task."""
-    print(f"Fetching data at {datetime.datetime.now().isoformat()}")
-    # TODO: Implement actual data fetching logic
+    """Run a single data fetch immediately."""
+    print(f"Manual fetch at {datetime.now().isoformat()}")
+    job_fetch_views()
 

--- a/sns_dashboard/tasks.py
+++ b/sns_dashboard/tasks.py
@@ -1,0 +1,8 @@
+import datetime
+
+
+def fetch_data() -> None:
+    """Placeholder for daily data collection task."""
+    print(f"Fetching data at {datetime.datetime.now().isoformat()}")
+    # TODO: Implement actual data fetching logic
+

--- a/sns_dashboard/viz.py
+++ b/sns_dashboard/viz.py
@@ -1,0 +1,21 @@
+import matplotlib.pyplot as plt
+from .db import get_daily_views
+
+
+def plot_views() -> None:
+    rows = get_daily_views()
+    if not rows:
+        print("No data to plot")
+        return
+    dates = sorted(set(r["date"] for r in rows))
+    platforms = sorted(set(r["platform"] for r in rows))
+    data = {p: [0 for _ in dates] for p in platforms}
+    idx = {d: i for i, d in enumerate(dates)}
+    for r in rows:
+        data[r["platform"]][idx[r["date"]]] = r["views"]
+    for p, vals in data.items():
+        plt.plot(dates, vals, label=p)
+    plt.legend()
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.show()


### PR DESCRIPTION
## Summary
- schedule daily data collection with new `run` command
- implement placeholder `fetch_data` task
- document the scheduler usage in README

## Testing
- `python -m sns_dashboard.main --help`
- `python -m sns_dashboard.main run` *(terminated early)*
- `python - <<'PY'
from sns_dashboard.tasks import fetch_data
fetch_data()
PY`

------
https://chatgpt.com/codex/tasks/task_e_686e6e92073483298dd1a233bcc3f75e