### PR TITLE
Expand setup to collect API credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+data.db

--- a/.vibe/project.json
+++ b/.vibe/project.json
@@ -1,1 +1,6 @@
-json<br>{<br> "name": "hello-ys",<br> "description": "Vibe Coding 테스트 프로젝트",<br> "language": "javascript",<br> "createdWith": "Codex"<br>}<br>
+{
+  "name": "hello-ys",
+  "description": "Vibe Coding 테스트 프로젝트",
+  "language": "javascript",
+  "createdWith": "Codex"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# SNS Dashboard
+
+This project collects daily view counts from YouTube, TikTok and Instagram channels and computes estimated revenue. A small Tkinter GUI lets you enter API credentials, channel URLs and CPM rates which are saved to `config.json`.
+
+## Usage
+
+Install dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
+To launch the GUI, run one of:
+
+```bash
+python -m sns_dashboard setup
+```
+
+or
+
+```bash
+python -m sns_dashboard.main setup
+```
+
+You can also execute the script directly:
+
+```bash
+python sns_dashboard/main.py setup
+```
+
+Running `python sns_dashboard/main.py` without any arguments will launch the setup window on first run. If `config.json` already exists and is filled out, the scheduler starts automatically instead. You can also run `python -m sns_dashboard` for the same behavior.
+
+If packaged as an executable, you can invoke the setup with:
+
+```bash
+sns-dashboard.exe setup
+```
+
+Fill in each credential field along with the three channel URLs and optional CPM rates, then press **Save**. The configuration will be written to `config.json` and an initial authentication step will run.
+
+## Scheduled Data Collection
+
+After completing the setup you can start a background process that collects data each day at midnight:
+
+```bash
+python -m sns_dashboard run
+```
+
+This command initializes the SQLite database and schedules a fetch job every day at 00:00.
+
+If the configuration file already exists, you can simply run:
+
+```bash
+python -m sns_dashboard
+```
+
+or run the packaged executable to start the scheduler immediately.
+
+Collected data can be visualized with:
+
+```bash
+python -m sns_dashboard plot
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SNS Dashboard
 
-This project collects daily view counts from YouTube, TikTok and Instagram channels and computes estimated revenue. A small Tkinter GUI lets you enter API credentials, channel URLs and CPM rates which are saved to `config.json`.
+This project collects daily view counts from YouTube, TikTok and Instagram channels and computes estimated revenue. A small Tkinter GUI asks for each channel URL and its CPM rate and stores them in `config.json`.
 
 ## Usage
 
@@ -36,7 +36,7 @@ If packaged as an executable, you can invoke the setup with:
 sns-dashboard.exe setup
 ```
 
-Fill in each credential field along with the three channel URLs and optional CPM rates, then press **Save**. The configuration will be written to `config.json` and an initial authentication step will run.
+Fill in the three channel URLs and CPM values, then press **Save**. The configuration will be written to `config.json`.
 
 ## Scheduled Data Collection
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,17 @@
+{
+  "google_client_id": "",
+  "google_client_secret": "",
+  "instagram_client_id": "",
+  "instagram_client_secret": "",
+  "tiktok_client_key": "",
+  "tiktok_client_secret": "",
+  "spreadsheet_id": "",
+  "youtube_url": "",
+  "tiktok_url": "",
+  "instagram_url": "",
+  "rates": {
+    "youtube": 0.1,
+    "tiktok": 0.1,
+    "instagram": 0.1
+  }
+}

--- a/config.json
+++ b/config.json
@@ -1,17 +1,10 @@
 {
-  "google_client_id": "",
-  "google_client_secret": "",
-  "instagram_client_id": "",
-  "instagram_client_secret": "",
-  "tiktok_client_key": "",
-  "tiktok_client_secret": "",
-  "spreadsheet_id": "",
   "youtube_url": "",
   "tiktok_url": "",
   "instagram_url": "",
   "rates": {
-    "youtube": 0.1,
-    "tiktok": 0.1,
-    "instagram": 0.1
+    "youtube": 0.0,
+    "tiktok": 0.0,
+    "instagram": 0.0
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+typer
+apscheduler
+matplotlib

--- a/sns_dashboard/__main__.py
+++ b/sns_dashboard/__main__.py
@@ -1,0 +1,4 @@
+from .main import app
+
+if __name__ == "__main__":
+    app()

--- a/sns_dashboard/auth.py
+++ b/sns_dashboard/auth.py
@@ -1,0 +1,16 @@
+from .config import load_config
+
+
+def get_token() -> None:
+    """Simulate initial authentication using saved credentials."""
+    cfg = load_config()
+    print("Performing initial authentication...")
+    creds = [
+        cfg.get("google_client_id"),
+        cfg.get("instagram_client_id"),
+        cfg.get("tiktok_client_key"),
+    ]
+    if all(creds):
+        print("Credentials loaded. (authentication stub)")
+    else:
+        print("Missing credentials; authentication skipped")

--- a/sns_dashboard/auth.py
+++ b/sns_dashboard/auth.py
@@ -1,16 +1,3 @@
-from .config import load_config
-
-
 def get_token() -> None:
-    """Simulate initial authentication using saved credentials."""
-    cfg = load_config()
-    print("Performing initial authentication...")
-    creds = [
-        cfg.get("google_client_id"),
-        cfg.get("instagram_client_id"),
-        cfg.get("tiktok_client_key"),
-    ]
-    if all(creds):
-        print("Credentials loaded. (authentication stub)")
-    else:
-        print("Missing credentials; authentication skipped")
+    """Stub authentication step using built-in credentials."""
+    print("Performing initial authentication... (stub)")

--- a/sns_dashboard/config.py
+++ b/sns_dashboard/config.py
@@ -1,0 +1,57 @@
+import json
+import os
+from typing import Any, Dict
+
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.json")
+
+DEFAULT_CONFIG = {
+    "google_client_id": "",
+    "google_client_secret": "",
+    "instagram_client_id": "",
+    "instagram_client_secret": "",
+    "tiktok_client_key": "",
+    "tiktok_client_secret": "",
+    "spreadsheet_id": "",
+    "youtube_url": "",
+    "tiktok_url": "",
+    "instagram_url": "",
+    "rates": {
+        "youtube": 0.1,
+        "tiktok": 0.1,
+        "instagram": 0.1,
+    },
+}
+
+
+def config_exists() -> bool:
+    """Return True if the configuration file exists."""
+    return os.path.exists(CONFIG_PATH)
+
+
+def is_config_complete(cfg: Dict[str, Any]) -> bool:
+    """Return True if all credential and URL fields are provided."""
+    required = [
+        "google_client_id",
+        "google_client_secret",
+        "instagram_client_id",
+        "instagram_client_secret",
+        "tiktok_client_key",
+        "tiktok_client_secret",
+        "spreadsheet_id",
+        "youtube_url",
+        "tiktok_url",
+        "instagram_url",
+    ]
+    return all(cfg.get(k) for k in required)
+
+
+def load_config() -> Dict[str, Any]:
+    if not os.path.exists(CONFIG_PATH):
+        return DEFAULT_CONFIG.copy()
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)

--- a/sns_dashboard/config.py
+++ b/sns_dashboard/config.py
@@ -5,20 +5,13 @@ from typing import Any, Dict
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.json")
 
 DEFAULT_CONFIG = {
-    "google_client_id": "",
-    "google_client_secret": "",
-    "instagram_client_id": "",
-    "instagram_client_secret": "",
-    "tiktok_client_key": "",
-    "tiktok_client_secret": "",
-    "spreadsheet_id": "",
     "youtube_url": "",
     "tiktok_url": "",
     "instagram_url": "",
     "rates": {
-        "youtube": 0.1,
-        "tiktok": 0.1,
-        "instagram": 0.1,
+        "youtube": 0.0,
+        "tiktok": 0.0,
+        "instagram": 0.0,
     },
 }
 
@@ -29,19 +22,8 @@ def config_exists() -> bool:
 
 
 def is_config_complete(cfg: Dict[str, Any]) -> bool:
-    """Return True if all credential and URL fields are provided."""
-    required = [
-        "google_client_id",
-        "google_client_secret",
-        "instagram_client_id",
-        "instagram_client_secret",
-        "tiktok_client_key",
-        "tiktok_client_secret",
-        "spreadsheet_id",
-        "youtube_url",
-        "tiktok_url",
-        "instagram_url",
-    ]
+    """Return True if all channel URLs are provided."""
+    required = ["youtube_url", "tiktok_url", "instagram_url"]
     return all(cfg.get(k) for k in required)
 
 

--- a/sns_dashboard/db.py
+++ b/sns_dashboard/db.py
@@ -1,0 +1,73 @@
+import os
+import sqlite3
+from typing import Iterable, Tuple
+
+DB_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data.db")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS channels (
+    platform TEXT PRIMARY KEY,
+    url TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rates (
+    platform TEXT PRIMARY KEY,
+    cpm REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS views (
+    platform TEXT,
+    date DATE,
+    views INTEGER,
+    PRIMARY KEY(platform, date)
+);
+
+CREATE VIEW IF NOT EXISTS earnings AS
+SELECT v.platform,
+       v.date,
+       v.views,
+       ROUND(v.views / 1000.0 * r.cpm, 2) AS revenue
+FROM   views v
+JOIN   rates r USING(platform);
+
+CREATE VIEW IF NOT EXISTS views_monthly AS
+SELECT platform,
+       substr(date, 1, 7) AS yyyymm,
+       SUM(views) AS views_month
+FROM views
+GROUP BY platform, yyyymm;
+
+CREATE VIEW IF NOT EXISTS earnings_monthly AS
+SELECT v.platform,
+       v.yyyymm,
+       v.views_month,
+       ROUND(v.views_month / 1000.0 * r.cpm, 2) AS revenue_month
+FROM views_monthly v
+JOIN rates r USING(platform);
+"""
+
+
+def get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    conn = get_conn()
+    conn.executescript(SCHEMA)
+    conn.commit()
+
+
+def insert_views(platform: str, date: str, views: int) -> None:
+    conn = get_conn()
+    conn.execute(
+        "INSERT OR REPLACE INTO views(platform, date, views) VALUES (?, ?, ?)",
+        (platform, date, views),
+    )
+    conn.commit()
+
+
+def get_daily_views() -> Iterable[Tuple[str, str, int]]:
+    conn = get_conn()
+    return conn.execute("SELECT platform, date, views FROM views ORDER BY date").fetchall()

--- a/sns_dashboard/earnings.py
+++ b/sns_dashboard/earnings.py
@@ -1,0 +1,10 @@
+from .db import get_conn
+
+
+def update_today() -> None:
+    # Simple calculation using views and rates tables
+    conn = get_conn()
+    conn.execute(
+        "INSERT OR REPLACE INTO earnings SELECT v.platform, v.date, v.views, ROUND(v.views / 1000.0 * r.cpm, 2) FROM views v JOIN rates r USING(platform)"
+    )
+    conn.commit()

--- a/sns_dashboard/fetchers/instagram.py
+++ b/sns_dashboard/fetchers/instagram.py
@@ -1,0 +1,4 @@
+def get_channel_views() -> int:
+    """Return total lifetime views for the given Instagram account."""
+    print("Fetching Instagram views (stub)")
+    return 0

--- a/sns_dashboard/fetchers/tiktok.py
+++ b/sns_dashboard/fetchers/tiktok.py
@@ -1,0 +1,4 @@
+def get_channel_views() -> int:
+    """Return total lifetime views for the given TikTok channel."""
+    print("Fetching TikTok views (stub)")
+    return 0

--- a/sns_dashboard/fetchers/youtube.py
+++ b/sns_dashboard/fetchers/youtube.py
@@ -1,0 +1,5 @@
+def get_channel_views() -> int:
+    """Return total lifetime views for the given YouTube channel."""
+    # TODO: implement actual API call
+    print("Fetching YouTube views (stub)")
+    return 0

--- a/sns_dashboard/gui.py
+++ b/sns_dashboard/gui.py
@@ -2,7 +2,6 @@ import tkinter as tk
 from tkinter import messagebox
 
 from .config import load_config, save_config
-from .auth import get_token
 
 
 class SetupGUI:
@@ -12,13 +11,6 @@ class SetupGUI:
 
         self.entries = {}
         fields = [
-            ("Google Client ID", "google_client_id"),
-            ("Google Client Secret", "google_client_secret"),
-            ("Instagram Client ID", "instagram_client_id"),
-            ("Instagram Client Secret", "instagram_client_secret"),
-            ("TikTok Client Key", "tiktok_client_key"),
-            ("TikTok Client Secret", "tiktok_client_secret"),
-            ("Spreadsheet ID", "spreadsheet_id"),
             ("YouTube Channel URL", "youtube_url"),
             ("TikTok Channel URL", "tiktok_url"),
             ("Instagram Channel URL", "instagram_url"),
@@ -62,7 +54,6 @@ class SetupGUI:
         data["rates"] = rates
         save_config(data)
         messagebox.showinfo("Saved", "Configuration saved.")
-        get_token()
 
 
 def run():

--- a/sns_dashboard/gui.py
+++ b/sns_dashboard/gui.py
@@ -1,0 +1,75 @@
+import tkinter as tk
+from tkinter import messagebox
+
+from .config import load_config, save_config
+from .auth import get_token
+
+
+class SetupGUI:
+    def __init__(self, master: tk.Tk):
+        self.master = master
+        master.title('SNS Dashboard Setup')
+
+        self.entries = {}
+        fields = [
+            ("Google Client ID", "google_client_id"),
+            ("Google Client Secret", "google_client_secret"),
+            ("Instagram Client ID", "instagram_client_id"),
+            ("Instagram Client Secret", "instagram_client_secret"),
+            ("TikTok Client Key", "tiktok_client_key"),
+            ("TikTok Client Secret", "tiktok_client_secret"),
+            ("Spreadsheet ID", "spreadsheet_id"),
+            ("YouTube Channel URL", "youtube_url"),
+            ("TikTok Channel URL", "tiktok_url"),
+            ("Instagram Channel URL", "instagram_url"),
+            ("YouTube CPM", "rate_youtube"),
+            ("TikTok CPM", "rate_tiktok"),
+            ("Instagram CPM", "rate_instagram"),
+        ]
+
+        for i, (label_text, key) in enumerate(fields):
+            tk.Label(master, text=label_text).grid(row=i, column=0, sticky='e', pady=2, padx=2)
+            entry = tk.Entry(master, width=40)
+            entry.grid(row=i, column=1, pady=2, padx=2)
+            self.entries[key] = entry
+
+        tk.Button(master, text='Save', command=self.save).grid(row=len(fields), column=0, columnspan=2, pady=10)
+
+        self.load_existing()
+
+    def load_existing(self):
+        data = load_config()
+        for key, entry in self.entries.items():
+            if key.startswith("rate_"):
+                platform = key.split("_", 1)[1]
+                value = data.get("rates", {}).get(platform)
+            else:
+                value = data.get(key)
+            if value is not None:
+                entry.delete(0, tk.END)
+                entry.insert(0, str(value))
+
+    def save(self):
+        data = load_config()
+        for key, entry in self.entries.items():
+            if key.startswith("rate_"):
+                continue
+            data[key] = entry.get().strip()
+        rates = data.get("rates", {})
+        rates["youtube"] = float(self.entries["rate_youtube"].get() or 0)
+        rates["tiktok"] = float(self.entries["rate_tiktok"].get() or 0)
+        rates["instagram"] = float(self.entries["rate_instagram"].get() or 0)
+        data["rates"] = rates
+        save_config(data)
+        messagebox.showinfo("Saved", "Configuration saved.")
+        get_token()
+
+
+def run():
+    root = tk.Tk()
+    SetupGUI(root)
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    run()

--- a/sns_dashboard/main.py
+++ b/sns_dashboard/main.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import time
+import typer
+
+if __package__ is None or __package__ == "":
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from sns_dashboard.gui import run as run_gui
+from sns_dashboard.scheduler import start as start_scheduler
+from sns_dashboard.viz import plot_views
+from sns_dashboard.db import init_db
+from sns_dashboard.config import load_config, config_exists, is_config_complete
+
+app = typer.Typer(help='SNS Dashboard Command Line Interface')
+
+
+@app.callback()
+def main() -> None:
+    """SNS Dashboard CLI."""
+    pass
+
+
+@app.command()
+def setup() -> None:
+    """Launch GUI setup window."""
+    run_gui()
+
+
+@app.command()
+def run() -> None:
+    """Start scheduler for daily data fetch."""
+    init_db()
+    start_scheduler()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+@app.command()
+def plot() -> None:
+    """Display a simple plot of collected views."""
+    plot_views()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        cfg = load_config() if config_exists() else None
+        if cfg is None or not is_config_complete(cfg):
+            sys.argv.append('setup')
+        else:
+            sys.argv.append('run')
+    app()

--- a/sns_dashboard/scheduler.py
+++ b/sns_dashboard/scheduler.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from .fetchers.youtube import get_channel_views as youtube_views
+from .fetchers.tiktok import get_channel_views as tiktok_views
+from .fetchers.instagram import get_channel_views as instagram_views
+from .db import insert_views
+
+scheduler = BackgroundScheduler(timezone="Asia/Seoul")
+
+
+def job_fetch_views() -> None:
+    today = datetime.now().date().isoformat()
+    print(f"Fetching views for {today}")
+    insert_views("youtube", today, youtube_views())
+    insert_views("tiktok", today, tiktok_views())
+    insert_views("instagram", today, instagram_views())
+
+
+def start() -> None:
+    if not scheduler.get_job("daily_fetch"):
+        scheduler.add_job(job_fetch_views, "cron", hour=0, id="daily_fetch")
+    scheduler.start()
+    print("Scheduler started. Running initial fetch...")
+    job_fetch_views()

--- a/sns_dashboard/tasks.py
+++ b/sns_dashboard/tasks.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from .scheduler import job_fetch_views
+from .db import init_db
+
+
+def fetch_data() -> None:
+    """Run a single data fetch immediately."""
+    print(f"Manual fetch at {datetime.now().isoformat()}")
+    init_db()
+    job_fetch_views()
+

--- a/sns_dashboard/viz.py
+++ b/sns_dashboard/viz.py
@@ -1,0 +1,21 @@
+import matplotlib.pyplot as plt
+from .db import get_daily_views
+
+
+def plot_views() -> None:
+    rows = get_daily_views()
+    if not rows:
+        print("No data to plot")
+        return
+    dates = sorted(set(r["date"] for r in rows))
+    platforms = sorted(set(r["platform"] for r in rows))
+    data = {p: [0 for _ in dates] for p in platforms}
+    idx = {d: i for i, d in enumerate(dates)}
+    for r in rows:
+        data[r["platform"]][idx[r["date"]]] = r["views"]
+    for p, vals in data.items():
+        plt.plot(dates, vals, label=p)
+    plt.legend()
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.show()


### PR DESCRIPTION
## Summary
- store API credentials along with channel URLs and CPM rates
- update GUI to capture credentials and trigger authentication after saving
- check configuration completeness against all fields
- refresh README with new setup instructions

## Testing
- `python -m sns_dashboard.main --help`
- `python - <<'PY'
from sns_dashboard.tasks import fetch_data
fetch_data()
PY`


------
https://chatgpt.com/codex/tasks/task_e_686e6e92073483298dd1a233bcc3f75e